### PR TITLE
render text within li if no child tag is present

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -1,5 +1,5 @@
 'use strict';
-var colors = require('ansicolors') 
+var colors = require('ansicolors')
   , blocks = {}
   , inlineDirectChildren = {};
 
@@ -24,27 +24,35 @@ var layout = module.exports = function layout(nodes, opts) {
       , block = blocks[node.tag]
       , prefix = ''
       , suffix = ''
-      ; 
-    
+      ;
+
     // prefix opened block elements with new line and add one after they close
     if (block && !inlineDirectChildren[parent]) {
       if (node.open) prefix += block.prefix;
       if (node.close) suffix += block.suffix;
     }
-    
+
     // give list items indent
-    if (node.open && node.tag === 'li') { 
+    if (node.open && node.tag === 'li') {
+      // if the li text contains text itself save it
+      const keepText = node.text.trim()
+
       // add list indent for current list item and any list item it is nested in (parents)
       node.text = opts.listIndent + listParents.reduce(function (acc, x) { return acc + opts.listIndent; }, '') + opts.listStyle;
+
+      if(keepText.length) {
+        // add the text back in
+        node.text += keepText
+      }
     }
-    
+
     // indent newlines of children under of list items
     if (listParents.length) {
       // indent them one more than the first line of the list item
       var indent = listParents.reduce(function (acc, x) { return acc + opts.listIndent; }, opts.listIndent);
       node.text = node.text.replace('\n', '\n' + indent);
     }
-    
+
     node.text = prefix + node.text + suffix;
     return node;
   }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,14 +10,14 @@ var sax = require('sax')
 [ 'li' ]
   .forEach(function (k) { layoutTags[k] = true; });
 
-  
+
 var parse = module.exports = function parse(s, opts, cb) {
   if (!cb) {
     cb = opts;
     opts = {};
   }
   if (!opts.hasOwnProperty('html')) opts.html = true;
- 
+
   var parser = sax.parser(opts.html, { trim: false })
     , tagStack = []
     , errors = []
@@ -35,7 +35,7 @@ var parse = module.exports = function parse(s, opts, cb) {
     // don't include current tag in parents
     parents.pop();
 
-    currentItem = { 
+    currentItem = {
         text    :  ''
       , parents :  parents
       , tag     :  tag.name
@@ -66,6 +66,11 @@ var parse = module.exports = function parse(s, opts, cb) {
   };
 
   parser.ontext = function (text) {
+    // fix for text being discarded if it is a li tag
+    // text is trimmed to get rid of "useless" line breaks and spaces
+    if(currentItem && currentItem.tag === 'li' && text.trim()) {
+      currentItem.text += text
+    }
     if (text.length && currentItem && !layoutTags[currentItem.tag]) currentItem.text += text;
   };
 
@@ -73,7 +78,7 @@ var parse = module.exports = function parse(s, opts, cb) {
     if (layoutTags[x.tag]) return true;
     if (ignoreTags[x.tag]) return false;
 
-    return x.tag === 'p' || x.tag === 'span' 
+    return x.tag === 'p' || x.tag === 'span'
       ? x.text.length
       : x.text.trim().length;
   }

--- a/test/layout.js
+++ b/test/layout.js
@@ -5,41 +5,41 @@ var test = require('tape')
   , parse = require('../lib/parse')
   , layout = require('../lib/layout')
   , render = require('../lib/render')
-  
+
 function inspect(obj, depth) {
   return require('util').inspect(obj, false, depth || 5, true);
 }
 
 var src = [
     '<h2>outside</h2>'
-  , '<ul>'  
-  , ' <li>' 
-  , '   <p>- One Level List</p>'  
-  , '     <ul>'  
-  , '       <li>' 
-  , '         <p>- Two Levels List</p>' 
-  , '       </li>'  
-  , '     </ul>'  
-  , ' </li>'  
+  , '<ul>'
+  , ' <li>'
+  , '   <p>- One Level List</p>'
+  , '     <ul>'
+  , '       <li>'
+  , '         <p>- Two Levels List</p>'
+  , '       </li>'
+  , '     </ul>'
+  , ' </li>'
   , '</ul>'
 ].join('\n')
 
 test('render parsed: \n' + src + '\nwith list indent "12" and listStyle: "> "', function (t) {
   parse(src, function (err, res) {
-    var expected = 
-          '\n\noutside\n12> - One Level List\n' 
+    var expected =
+          '\n\noutside\n12> - One Level List\n'
         + '\n1212> - Two Levels List\n\n'
       , layedout = layout(res, { listIndent: '12', listStyle: '> ' })
       , result = render(layedout)
 
     t.equals(result, expected, 'returns result that renders to ' + expected)
     t.end()
-  });  
+  });
 })
 
 test('render parsed: \n' + src + '\nwith list indent "1234" and listStyle: "> "', function (t) {
   parse(src, function (err, res) {
-    var expected = 
+    var expected =
           '\n\noutside\n1234> - One Level List\n'
         + '\n12341234> - Two Levels List\n\n'
       , layedout = layout(res, { listIndent: '1234', listStyle: '> ' })
@@ -47,5 +47,34 @@ test('render parsed: \n' + src + '\nwith list indent "1234" and listStyle: "> "'
 
     t.equals(result, expected, 'returns result that renders to ' + expected)
     t.end()
-  });  
+  });
+})
+
+
+// Test for li printing without a child
+
+var src_li_no_children = [
+  '<h2>outside</h2>'
+  , '<ul>'
+  , ' <li>'
+  , '   One Level List'
+  , '     <ul>'
+  , '       <li>'
+  , '         Two Levels List'
+  , '       </li>'
+  , '     </ul>'
+  , ' </li>'
+  , '</ul>'
+].join('\n')
+
+test('render parsed: \n' + src_li_no_children + '\nwith list indent "12" and listStyle: "> "', function (t) {
+  parse(src_li_no_children, function (err, res) {
+    var expected =
+        "\n\noutside\n12> One Level List\n1212> Two Levels List\n"
+        , layedout = layout(res, { listIndent: '12', listStyle: '> ' })
+        , result = render(layedout)
+
+    t.equals(result, expected, 'returns result that renders to ' + expected)
+    t.end()
+  });
 })


### PR DESCRIPTION
I am not sure if anyone still cares about this project, but here would be a fix for this bug: https://github.com/thlorenz/hermit/issues/2

I didn't go crazy deep into the internals of this project, but the main changes I made are that I check in parse.js in the function parser.ontext if the li tag has "real text" meaning other text than blanks and line breaks, if that is the case I add the text to currentItem.

in layout.js in the function processNode

I check if the li tag has text, if it does, I add it back after the indention.


I am not sure if this breaks anything else since I didn't go deep into the internals, but I added a test case and all the other tests still pass.


Sorry for the reformatting, if it bothers you and anybody still cares about the project I can start a new pull request without the reformatting.